### PR TITLE
Two Table View Plus Automatic Scrolling On Row Click

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Scripts
+preprocess_logs.py

--- a/index.html
+++ b/index.html
@@ -105,15 +105,19 @@
                 <button type="button" id="add-filter-btn" class="btn btn-primary">Add Filter</button>
                 <button type="button" id="save-filter-group-btn" class="btn btn-success">Save</button>
                 <button type="button" id="delete-filter-group-btn" class="btn btn-danger">Delete</button>
-              </div>              
+              </div>
             </div>
           </div>
         </div>
 
         <!-- Log Viewer -->
-        <div id="log-viewer" class="border p-3 rounded"
+        <div id="all-logs" class="border p-3 rounded"
           style="background-color: #f8f9fa; max-height: 500px; overflow-y: auto;">
           <p class="text-muted">Click "Load Logs" to view log data.</p>
+        </div>
+        <div id="filtered-logs" class="border p-3 rounded mt-3"
+          style="background-color: #f8f9fa; max-height: 500px; overflow-y: auto;">
+          <p class="text-muted">Click "Load Logs" to view filtered log data.</p>
         </div>
       </div>
     </div>

--- a/public/all-logs.json
+++ b/public/all-logs.json
@@ -1,0 +1,8002 @@
+[
+    {
+        "timestamp": "2025-01-16T14:18:52.024Z",
+        "level": "Debug",
+        "thread ID": "[0xd1ba62]",
+        "messages": [
+            "[]MediaApplication.cpp:318 startLogger::Started media logger. LogFile = ********/Library/Logs/SparkMacDesktop/media/calls/1737037131593_0e6b4dfa-ca34-4422-8f4a-9e260cad346c.log"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.024Z",
+        "level": "Debug",
+        "thread ID": "[0xd1ba62]",
+        "messages": [
+            "[]MediaApplication.cpp:556 onCommandReceived::Received ipc::Command::Type::CreateConnection, Creating Media Connection"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.024Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaApplication.cpp:334 createConnection::"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.025Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]VideoEffectManager.cpp:34 createVideoEffectFactory::type: Ladon, channel: Call"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.027Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WSE] CFrameRateFilter::Reset Target fps is 1.000"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.027Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WSE] CWseVideoPortraitFilterCoreML::CWseVideoPortraitFilterCoreML() end, this=0x138368000"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.027Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WSE] CWseVideoPortraitFilterCoreML::Init() begin [this=0x138368000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.027Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WSE] CWseVideoPortraitFilterCoreML::CreateThread(), CreateUserTaskThread() success, m_pThread = 0x142034000 [this=0x138368000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.027Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WSE] CWseVideoPortraitFilterCoreML::InitMetal() begin [this=0x138368000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.029Z",
+        "level": "Debug",
+        "thread ID": "[0xd1ba62]",
+        "messages": [
+            "[]MediaApplicationOSX.mm:37 runOnMainThread::Adding task DeviceManagerPeer::setDeviceMuteState() to the task queue. Task queue size: 2, current task name: MediaApplication::createConnection"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.029Z",
+        "level": "Debug",
+        "thread ID": "[0xd1ba62]",
+        "messages": [
+            "[]MediaApplicationOSX.mm:37 runOnMainThread::Adding task DeviceManagerPeer::getVolume() to the task queue. Task queue size: 3, current task name: MediaApplication::createConnection"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.034Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WSE] CWseVideoPortraitFilterCoreML::InitMetal() end [this=0x138368000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.034Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WSE] CFrameRateFilter::Reset Target fps is 6.000"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.034Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WSE] CWseVideoPortraitFilterCoreML::InitWithML() begin [this=0x138368000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.034Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] get_cpu_core cpu_performace_core_num = 8, cpu_efficiency_core_num = 4, old physical_core_num = 12, modelNum = 2"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.034Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] get_cpu_core new physical_core_num = 12"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.034Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WSE] CWseVideoPortraitFilterCoreML::get_ladon_model_path, g_sLadonLibPath: ********/Library/Application Support/Cisco Spark/Webexteams_upgrades_arm/45.1.0.31546_604bd55d-9d56-4040-a185-a7063dfb3aec/dynamic_components/ladon/ladon"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.034Z",
+        "level": "Info",
+        "thread ID": "[0xd287ab]",
+        "messages": [
+            "[]WME:0 ::[WSE] CWseVideoPortraitFilterCoreML::InitWithML(), init model [this=0x138368000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.036Z",
+        "level": "Info",
+        "thread ID": "[0xd287ab]",
+        "messages": [
+            "[]WME:0 ::[WSE] CWseVideoPortraitFilterCoreML::InitWithML(), g_mlModelVersion=LadonMedium_640360_Chan4_v083_08222024, m_bEnableLadonModel=1 [this=0x138368000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.039Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[ProcessCoreML] MLFilter mode is CPU and GPU, this=0x138368000"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.039Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[ProcessCoreML] MLFilter getGpuInfo: name= Apple M2 Pro, this=0x138368000"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.039Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WSE] CWseVideoPortraitFilterCoreML::InitWithML() end [this=0x138368000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.039Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WSE] CWseVideoPortraitFilterCoreML::Init() end, m_bEnableLadonModel=1, this=0x138368000"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.040Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeVideoPortraitEffect::CWmeVideoPortraitEffect end [this=0x140788630]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.040Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]VideoEffectFactory.cpp:61 setSavedParams::[Ladon][Call] param type: None"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.040Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaEngine.cpp:810 createMediaConnection::MediaEngine::createMediaConnection"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.041Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2385 Connection:: this 0x14220da18"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.041Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2397 Connection::set mStartTrackReadyFlags as true"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]ConnectionPeer.cpp:41 initialize::Initialize media connection. ID = [11eec45a-8f3a-4a6f-8702-fc225f611808]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2428 init::init() notify ConnectionState::Created"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaApplicationOSX.mm:37 runOnMainThread::Adding task IMediaConnectionSink::onConnectionStateChanged(ConnectionState::Created) to the task queue. Task queue size: 4, current task name: MediaApplication::createConnection"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]ConnectionPeer.cpp:55 initialize::Immersive share is enabled: 1"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaApplication.cpp:340 createConnection::Create media connection. Id = [11eec45a-8f3a-4a6f-8702-fc225f611808], client version: 45.1.0.31546"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaDeviceManager.cpp:2474 setDeviceMuteState::Device type: 1 isMuted:0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaDeviceManager.cpp:2480 setDeviceMuteState::Set device mute state, device type: 1"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeAudioVolumeController::UnMute,line=481 [this=0x1421fe800] Enter..., nType=0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295][MACOSX ]:WBXVolumeControlMac::UnMute(), m_DeviceID:98, sCoreID:BuiltInMicrophoneDevice [cid=4294967295] [this=0x142202e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295][MACOSX ]:WBXVolumeControlMac::UnMute(), m_DeviceID:98, m_iType:0, sCoreID:BuiltInMicrophoneDevice,Success! [cid=4294967295] [this=0x142202e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeAudioVolumeController:UnMute(),Control type(0:APP, 1:System):0, result:0 [this=0x1421fe800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeAudioVolumeController::UnMute,line=481 [this=0x1421fe800] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaDeviceManager.cpp:2251 getVolume::enter"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.042Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaDeviceManager.cpp:2270 getVolume::device type 1 unmute, volume 12287 for ctrl type 0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.044Z",
+        "level": "Debug",
+        "thread ID": "[0xd1ba62]",
+        "messages": [
+            "[]ConnectionPeer.cpp:236 onDataReceived::Received ipc::Command::Type::SetFeatureToggles"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.045Z",
+        "level": "Debug",
+        "thread ID": "[0xd287ab]",
+        "messages": [
+            "[]ConnectionPeer.cpp:238 operator()::Processing ipc::Command::Type::SetFeatureToggles"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.045Z",
+        "level": "Debug",
+        "thread ID": "[0xd1ba62]",
+        "messages": [
+            "[]MediaApplicationOSX.mm:37 runOnMainThread::Adding task IMediaConnection:connect() to the task queue. Task queue size: 2, current task name: IMediaConnection:setFeatureToggles()"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.045Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2453 connect::Enter, initAudioMuteState:[0], initLocalVideoMuteState:[0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.045Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaApplicationOSX.mm:37 runOnMainThread::Adding task Connection::connect() to the task queue. Task queue size: 2, current task name: IMediaConnection:connect()"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.045Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:424 initWmeConnection::initWmeConnection"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.045Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:1869 removeVideoEffects::local videoTrack is null"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.046Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] WMEFuncAPI wme::CreateMediaConnection,line=274 Enter... [cid=0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.046Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CreateMediaConnection real cid [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.047Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.047Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::WmeConfig [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.047Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.048Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.048Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CReachableViaRecorder::Reset"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.048Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CReachableViaRecorder::clearIceRecords, records size:0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CGlobalConfig::CGlobalConfig,line=5195 [cid=3691033875] [this=0x1410d5668] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CGlobalConfig::CGlobalConfig,line=5195 [cid=3691033875] [this=0x1410d5668] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::CMediaConnection,line=223 [cid=3691033875] [this=0x1410d2c00] Enter..., callId=3691033875, externalTransport=0, svs=0, externalCsi=0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::CMediaConnection,line=223 [cid=3691033875] [this=0x1410d2c00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::Init,line=266 [cid=3691033875] [this=0x1410d2c00] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] [CheckPoint][Audio][Video][ScreenShare]CMediaConnection::Init version=15.1.0.5043,build=WME build:5043, WME revision:e75ac79,osinfo=mac,15.2.0,arm64,model=Mac14,10 [cid=3691033875] [this=0x1410d2c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wme trace mask 2"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141067800] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141067800] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141067800] Enter..., aType=-1, aFlag=1, Register=1, name=t-tick"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] thread type is TT_UNKNOWN"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x16f3eb000 [this=0x141067800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd2a106]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=t-tick, m_Tid=0x16f3eb000 [this=0x141067800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd2a106]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CCmThreadTask::OnThreadRun, Begin. name=t-tick [this=0x141067800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x141067800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] RegisterThread, thread=0x141067800 tid=0x16f3eb000 name=t-tick type=-1 eventQueue=0x141067b08 timerQueue=0x1406231c0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141067800] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd2a106]",
+        "messages": [
+            "[]WME:0 ::[UTIL] low_tick_generator::start [this=0x600000454b90]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::WmeCreateMediaEngineEx,line=246 Enter..., bSharedEngine=0, callId=3691033875, bTrainUse=0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CWmeMediaEngine,line=67 [cid=3691033875] [this=0x140725440] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::CWmeMediaEngine, end, m_bSharedEngine=0, m_callId=3691033875 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.049Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CWmeMediaEngine,line=67 [cid=3691033875] [this=0x140725440] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::SetCaptureRawDataEnable m_bEnableRawDataforCapture=0 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::SetPlaybackRawDataEnable m_bEnableRawDataforplayback=0 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::SetTrainSolutionFlag m_bEnableTainSolution=0 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::SetIOSVPIOEnable m_bEnableIOSVPIO=0 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::SetIOSSessionControlDisable m_bDisableIOSAudioSessionCtrl=0 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::SetTCAECEnable m_bEnableTCAEC=0 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] WmeCreateMediaEngineEx, end. bSingleEngine=0, callId=3691033875, bTrainUse=0,g_AndroidAudioMode= -1"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::WmeCreateMediaEngineEx,line=246 Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CreateNetworkIndicator,line=819 [cid=3691033875] [this=0x140725440] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CreateNetworkIndicator,line=819 [cid=3691033875] [this=0x140725440] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = LevelTop"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = overrideQuality"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = HWEnabled"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = vendor"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = model"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = virtCore"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = OSver"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = performanceLevel"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CmSystemInformation::CmSystemInformation [this=0x600002869300]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] get_cpu_core cpu_performace_core_num = 8, cpu_efficiency_core_num = 4, old physical_core_num = 12, modelNum = 2"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] get_cpu_core new physical_core_num = 12"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CmSystemInformation::~CmSystemInformation [this=0x600002869300]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] wme::CMediaSPCHelper::QueryMediaPerformance, WmeSessionType = 0 Sender bHWEnable=0 Performance =LevelHighPlus"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::SetAudioStaticPerfLevel level:4 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::GetLocalIp,line=5497 [cid=3691033875] [this=0x1410d2c00] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc get_local_addr,line=567 Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] getPrimaryIp is: 10.230.72.50"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] get_local_addr, IP Address = en0, 2001:420:4086:1258:b08e:79be:9ccb:8425, expire=592543s, flag6=4"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] get_local_addr, IP Address = en0, 10.230.72.50"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc get_local_addr,line=567 Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::GetLocalIp,line=5497 [cid=3691033875] [this=0x1410d2c00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.050Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::initRandomSeed,line=5522 [cid=3691033875] [this=0x1410d2c00] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] rand seed: 17370371320x1410d2c000x1407254400x1f9b6c24010.230.72.50, hash: 2695102329 [cid=3691033875] [this=0x1410d2c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] RAND_status() == 1, return [cid=3691033875] [this=0x1410d2c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::initRandomSeed,line=5522 [cid=3691033875] [this=0x1410d2c00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CMediaConnection::Init m_iceTieBreaker=14647433872133414032 [Audio][Video][ScreenShare] [cid=3691033875] [this=0x1410d2c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = LevelTop"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = overrideQuality"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = HWEnabled"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = vendor"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = model"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = virtCore"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CMediaPerformanceStaticControl::validateSpec, Validating spec SUCCESS for = cpuFreq"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = OSver"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = performanceLevel"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CmSystemInformation::CmSystemInformation [this=0x60000286bfb0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CmSystemInformation::~CmSystemInformation [this=0x60000286bfb0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] wme::CMediaSPCHelper::QueryMediaPerformance, WmeSessionType = 1 Sender bHWEnable=1 Performance =LevelHighPlus"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = LevelTop"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = overrideQuality"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = HWEnabled"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = vendor"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = model"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = virtCore"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = OSver"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] jsonHelper::operator[], can't find node = performanceLevel"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CmSystemInformation::CmSystemInformation [this=0x600002869300]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] get_cpu_core cpu_performace_core_num = 8, cpu_efficiency_core_num = 4, old physical_core_num = 12, modelNum = 2"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] get_cpu_core new physical_core_num = 12"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CmSystemInformation::CmSystemInformation [this=0x60000286bfc0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] get_cpu_core cpu_performace_core_num = 8, cpu_efficiency_core_num = 4, old physical_core_num = 12, modelNum = 2"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] get_cpu_core new physical_core_num = 12"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CmSystemInformation::~CmSystemInformation [this=0x60000286bfc0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CMediaPerformanceStaticControl::IsSupportPerformanceLevelTop() = 1"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CmSystemInformation::~CmSystemInformation [this=0x600002869300]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::getMQECpuInfo,line=6412 [cid=3691033875] [this=0x1410d2c00] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CmSystemInformation::CmSystemInformation [this=0x60000286bfc0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] get_cpu_core cpu_performace_core_num = 8, cpu_efficiency_core_num = 4, old physical_core_num = 12, modelNum = 2"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] get_cpu_core new physical_core_num = 12"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CmSystemInformation::~CmSystemInformation [this=0x60000286bfc0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::getMQECpuInfo,line=6412 [cid=3691033875] [this=0x1410d2c00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::getMQEGpuInfo,line=6448 [cid=3691033875] [this=0x1410d2c00] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] GetGpuDescription Name: Apple M2 Pro, memory 10922"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::getMQEGpuInfo,line=6448 [cid=3691033875] [this=0x1410d2c00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::subscribeConfig, Feature, EnableAdaptiveInitialBandwidth, 1, m_TotalObservers=0, pRunThread=0x0, bAsync=1 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::subscribeConfig, Transmission, WmeNetworkType, 2, m_TotalObservers=1, pRunThread=0x0, bAsync=1 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::Init,line=266 [cid=3691033875] [this=0x1410d2c00] Leave, cost=2ms"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] WMEFuncAPI wme::CreateMediaConnection,line=274 Leave, cost=5ms"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::SetEnableHDAudio() EnableHDAudio = 1, wmeResult = 0 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:450 initWmeConnection::Windows in-house Video background enabled: 1"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:453 initWmeConnection::Video stream de-duplication enabled: 0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:456 initWmeConnection::Android in-house Video background enabled: 0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2594 getInitializAudioDeviceCandidate::Candidate initializing Microphone with devID = [BuiltInMicrophoneDevice] and selection same as system, go check alignment"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2602 getInitializAudioDeviceCandidate::Candidate initializing Microphone with devID = [BuiltInMicrophoneDevice] same as currently selected"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2594 getInitializAudioDeviceCandidate::Candidate initializing Speaker with devID = [BuiltInSpeakerDevice] and selection same as system, go check alignment"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2602 getInitializAudioDeviceCandidate::Candidate initializing Speaker with devID = [BuiltInSpeakerDevice] same as currently selected"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2573 initializeDevices::Initializing devices. micId = [BuiltInMicrophoneDevice] speakerId = [BuiltInSpeakerDevice] cameraId = [3F45E80A-0176-46F7-B185-BB9E2C0E82E3]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.051Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:594 setDevice::setDevice:Name: [MacBook Pro Microphone] deviceId: [BuiltInMicrophoneDevice] serialNumber: [] DeviceType: [Microphone] TransportTypeString: [BuiltIn] isDefault: [1]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Error",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:16961 fireDeviceSelected::Media device report not enabled"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:594 setDevice::setDevice:Name: [MacBook Pro Speakers] deviceId: [BuiltInSpeakerDevice] serialNumber: [] DeviceType: [Speaker] TransportTypeString: [BuiltIn] isDefault: [1]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Error",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:16961 fireDeviceSelected::Media device report not enabled"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:594 setDevice::setDevice:Name: [FaceTime HD Camera] deviceId: [3F45E80A-0176-46F7-B185-BB9E2C0E82E3] serialNumber: [] DeviceType: [Camera] TransportTypeString: [Unknown] isDefault: [1]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Error",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:16961 fireDeviceSelected::Media device report not enabled"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Debug",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2583 initializeDevices::Microphone exist: true, Speaker exist: true, Camera exist: true"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::SetSink,line=3107 [cid=3691033875] [this=0x1410d2c00] Enter..., sink=0x14220da18"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Global, ClientSetSinkEvent,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnection::SetSink,line=3107 [cid=3691033875] [this=0x1410d2c00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2693 initializeMedia::Initialize media connection for call. ID = [11eec45a-8f3a-4a6f-8702-fc225f611808], mediaType = [Audio|Video|Share|ShareAudio|Application|ApplicationFecc]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2696 initializeMedia::mediaParams->isCSRCEnabled: 1"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2701 initializeMedia::mediaParams->isSendMediaStatusMetricsAllowed: true"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:2706 initializeMedia::mediaParams->isNewStartVideoBehaviorEnabled: true"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CGlobalConfig::SetFeatureTogglesEx,line=5644 [cid=3691033875] [this=0x1410d5668] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CGlobalConfig::SetFeatureTogglesEx {\"AaTestUserLevel\":\"true\",\"AdaptiveAudioBandwidthEnabled\":\"1\",\"DisablePlaybackNR\":\"true\",\"EnableAECJointNLP\":\"true\",\"EnableAdaptiveInitialBandwidth\":\"false\",\"EnableAgcOptimalParams\":\"true\",\"EnableAppPackAsSTUN\":\"true\",\"EnableAudioDynamicFec\":\"1\",\"EnableAudioSCROrder\":\"true\",\"EnableAudioUnderrunPLC\":\"true\",\"EnableBNR2_0\":\"true\",\"EnableCaptureDagc\":\"true\",\"EnableCscUseExternalVp\":\"true\",\"EnableDesktopNovaAECOpt\":\"true\",\"EnableDesktopST2_0\":\"true\",\"EnableDownsampleLanczosTune\":\"1\",\"EnableFECForRetransmission\":\"true\",\"EnableFullbandAudio\":\"true\",\"EnableGatherAudioDriverInfo\":\"false\",\"EnableGlobalAudioDeviceEnum\":\"true\",\"EnableImprovePLCContinuity\":\"true\",\"EnableMacScreenCaptureKit\":\"true\",\"EnableMacScreenCaptureKitImprovement\":\"true\",\"EnableMacScreenCaptureKitImprovementP2\":\"true\",\"EnableMacScreenCaptureKitPresenterOverlayAdaption\":\"true\",\"EnableMariDelayControl\":\"0\",\"EnableMariEmergencyBackoff\":\"1\",\"EnableNarrowBandDetectionMetrics\":\"false\",\"EnableNewAgc\":\"true\",\"EnableNovaAEC\":\"true\",\"EnableNovaAECOpt\":\"0\",\"EnableProbingControl\":\"true\",\"EnableRtpPaddingToProbe\":\"1\",\"EnableSPCForAudio\":\"true\",\"EnableSPCForXcodec\":\"true\",\"EnableSceneChangeDetection\":\"true\",\"EnableStereoAEC\":\"true\",\"EnableStereoContentAudio\":\"true\",\"EnableStereoTSM\":\"true\",\"EnableSuperResolution\":\"true\",\"EnableUDPFallbackTCP\":\"true\",\"EnableUnifyAudioUnitOnMac\":\"true\",\"EnableWMEDolphin30\":\"true\",\"EnableWebRTCAbsCaptureTime\":\"true\",\"EnableXcodec\":\"true\",\"EnableXcodecEncode\":\"1\",\"MariMaxQueueDurationInMs\":\"500\",\"MariQueueDrainParameter\":\"5\",\"ReviseG729FrameLength\":\"true\",\"SimulcastMultiEncoder\":\"true\",\"UsingAIContentDetect\":\"true\",\"xcodec\":\"true\"}"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, AaTestUserLevel,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, AdaptiveAudioBandwidthEnabled,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, DisablePlaybackNR,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableAECJointNLP,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableAdaptiveInitialBandwidth,  -> 0, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CMediaConnection::InitWmeConfig() Adaptive Initial Bandwidth Disabled [Audio][Video][ScreenShare] [cid=3691033875] [this=0x1410d2c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableAdaptiveInitialBandwidth, nObservers=1 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableAgcOptimalParams,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableAppPackAsSTUN,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableAudioDynamicFec,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableAudioSCROrder,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableAudioUnderrunPLC,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableBNR2_0,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableCaptureDagc,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableCscUseExternalVp,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableDesktopNovaAECOpt,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableDesktopST2_0,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableDownsampleLanczosTune,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableFECForRetransmission,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableFullbandAudio,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableGatherAudioDriverInfo,  -> 0, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableGlobalAudioDeviceEnum,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableImprovePLCContinuity,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableMacScreenCaptureKit,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableMacScreenCaptureKitImprovement,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableMacScreenCaptureKitImprovementP2,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableMacScreenCaptureKitPresenterOverlayAdaption,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableMariDelayControl,  -> 0, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableMariEmergencyBackoff,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableNarrowBandDetectionMetrics,  -> 0, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableNewAgc,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableNovaAEC,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableNovaAECOpt,  -> 0, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableProbingControl,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.052Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableRtpPaddingToProbe,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableSPCForAudio,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableSPCForXcodec,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableSceneChangeDetection,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableStereoAEC,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableStereoContentAudio,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableStereoTSM,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableSuperResolution,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableUDPFallbackTCP,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableUnifyAudioUnitOnMac,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableWMEDolphin30,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableWebRTCAbsCaptureTime,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableXcodec,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, EnableXcodecEncode,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, MariMaxQueueDurationInMs,  -> 500, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, MariQueueDrainParameter,  -> 5, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, ReviseG729FrameLength,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, SimulcastMultiEncoder,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, UsingAIContentDetect,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::fireEvents, Feature, xcodec,  -> 1, bForceNotify=0 [cid=3691033875] [this=0x141066800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CGlobalConfig::SetFeatureTogglesEx, ret=0 [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::ReleaseWmeConfig [cid=0], counts=54"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CGlobalConfig::SetFeatureTogglesEx,line=5644 [cid=3691033875] [this=0x1410d5668] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CGlobalConfig::SetClientType, value=1 [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CMediaConnection::SetClientType, value=1 [cid=3691033875] [this=0x1410d2c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]MediaConnection.cpp:4262 addMedia::AddMedia - 0, ID = [11eec45a-8f3a-4a6f-8702-fc225f611808], direction:3"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] WMEFuncAPI wme::CMediaConnection::AddMedia,line=2353 [this=0x1410d2c00] Enter...[CheckPoint][Audio], mediaType=0, direction=3, mid=1, debugOption= [cid=3691033875] [this=0x1410d2c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc *wme::CMediaConnection::AddConnection,line=5320 [cid=3691033875] [this=0x1410d2c00] Enter..., mediaType=0, direction=3, mid=1"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CBaseConfig::CBaseConfig,line=120 [cid=3691033875] [this=0x142210ec8] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CBaseConfig::CBaseConfig,line=120 [cid=3691033875] [this=0x142210ec8] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CAudioConfig::CAudioConfig,line=777 [cid=3691033875] [this=0x142210df0] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CAudioConfig::CAudioConfig,line=777 [cid=3691033875] [this=0x142210df0] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CBaseConfig::CBaseConfig,line=120 [cid=3691033875] [this=0x1422110a0] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CBaseConfig::CBaseConfig,line=120 [cid=3691033875] [this=0x1422110a0] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CBaseVideoConfig::CBaseVideoConfig,line=3036 [cid=3691033875] [this=0x142210fe8] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CBaseVideoConfig::CBaseVideoConfig,line=3036 [cid=3691033875] [this=0x142210fe8] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CVideoConfig::CVideoConfig,line=4006 [cid=3691033875] [this=0x142210fd8] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CVideoConfig::CVideoConfig,line=4006 [cid=3691033875] [this=0x142210fd8] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CBaseConfig::CBaseConfig,line=120 [cid=3691033875] [this=0x1422112b0] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CBaseConfig::CBaseConfig,line=120 [cid=3691033875] [this=0x1422112b0] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CBaseVideoConfig::CBaseVideoConfig,line=3036 [cid=3691033875] [this=0x1422111f8] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CBaseVideoConfig::CBaseVideoConfig,line=3036 [cid=3691033875] [this=0x1422111f8] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CShareConfig::CShareConfig,line=4189 [cid=3691033875] [this=0x1422111b0] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CShareConfig::CShareConfig,line=4189 [cid=3691033875] [this=0x1422111b0] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CBaseConfig::CBaseConfig,line=120 [cid=3691033875] [this=0x1422113c0] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.053Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CBaseConfig::CBaseConfig,line=120 [cid=3691033875] [this=0x1422113c0] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.054Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnectionInfo::CMediaConnectionInfo,line=213 [Audio] [cid=3691033875] [this=0x14220f600] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.054Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CMediaConnectionInfo::CMediaConnectionInfo() [Audio] [cid=3691033875] [this=0x14220f600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.054Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnectionInfo::CMediaConnectionInfo,line=213 [Audio] [cid=3691033875] [this=0x14220f600] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.054Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CMediaConnectionInfo::Init,line=319 [Audio] [cid=3691033875] [this=0x14220f600] Enter..., m_mid=1, m_pMediaConn=0x1410d2c00"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.054Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CMediaConnectionInfo::Init, create CIceConnector object [Audio] [cid=3691033875] [this=0x14220f600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.054Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.054Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CIceConnector::SetPortRange, port range=[52000, 52199) [Application] [cid=3691033875] [this=0x14221fc18]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.055Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CIceConnector::SetPortRange, port range=[52000, 52049) [Audio] [cid=3691033875] [this=0x14221fc18]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.055Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[MediaSession] CMediaTrackMgr::CMediaTrackMgr Local [cid=3691033875] [this=0x140916a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.055Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CreateMediaSession,line=146 [cid=3691033875] [this=0x140725440] Enter...[Audio]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.055Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.055Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] wme::CWmeMediaSession::InitWmeConfig, callId=3691033875, sessionType=0 [this=0x140725680]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.056Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmePackageAllocatorLite::CWmePackageAllocatorLite end, uiAllignment=0 [this=0x60000117e560]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.058Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141039400] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.058Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141039400] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.058Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141039400] Enter..., aType=21, aFlag=1, Register=1, name=rtcp"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.058Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x16f503000 [this=0x141039400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.058Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10a]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=rtcp, m_Tid=0x16f503000 [this=0x141039400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.059Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10a]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CCmThreadTask::OnThreadRun, Begin. name=rtcp [this=0x141039400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.059Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x141039400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.059Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] RegisterThread, thread=0x141039400 tid=0x16f503000 name=rtcp type=21 eventQueue=0x141039708 timerQueue=0x140624bc0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.059Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141039400] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.059Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[RTP] CThreadSingleton(): thread launched"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.059Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[RTP] CRTCPHandler_A141852.1539694700::CRTCPHandler, cname=wrtp.3895965569 [+ObjLife Constructing+] [this=0x142033800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[RTP] CRTPSessionClient_A141852::SetInitialBandwidthImpl, bw=355555 [this=0x1428b70c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[RTP] COutboundConfig_A141852::SetInitialBandwidth: bandwidth=2844440bps [this=0x140624620]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[RTP] CRTPSessionClientAudio_A141852::CRTPSessionClientAudio [+ObjLife Constructing+] [this=0x1428b7000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[RTP] [CheckPoint][Audio]WRTPCreateRTPSessionClient RTP Session is created for session=0x1428b70c0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[RTP] CNetworkIndicatorImp::RegisterSessionClient, register Session Client, session = 0x1428b7540"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x140917a00] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x140917a00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x140917a00] Enter..., aType=-1, aFlag=1, Register=1, name=low-pri-stat"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] thread type is TT_UNKNOWN"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x170827000 [this=0x140917a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10c]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=low-pri-stat, m_Tid=0x170827000 [this=0x140917a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10c]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CCmThreadTask::OnThreadRun, Begin. name=low-pri-stat [this=0x140917a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x140917a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] RegisterThread, thread=0x140917a00 tid=0x170827000 name=low-pri-stat type=-1 eventQueue=0x140917d08 timerQueue=0x141917c30"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x140917a00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaSession::Init, create RTP session client success, m_eSessionType = 0, bRTCPEnabled = 1 [this=0x140725680]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[RTP] CRTPSessionClientAudio_A141852::SetMediaPackageAllocator: allocator = 0x60000117e560 [this=0x1428b70c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[RTP] COutboundConfig_A141852::SetPacketizationMode: mode = 0 [this=0x140624620]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaSession::Init, end, m_eSessionType = 0 [this=0x140725680]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.060Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CreateMediaSession,line=146 [cid=3691033875] [this=0x140725440] Leave, cost=5ms"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaSession::SetTransport, m_eSessionType = 0, pRTPSessionClient = 0x1428b7540, pTransport = 0x14220f600 [this=0x140725680]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[RTP] CRTPSessionClientAudio_A141852::SetMediaTransport: transport = 0x14220f600 [this=0x1428b70c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaSession::SetOption, WmeSessionOption_SetQosLabel, uSize = 10, label = 3691033875 [this=0x140725680]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[RTP] CRTPSessionClientAudio_A141852::CRTPSessionClient::EnableSendingCSRC enable = 1 [this=0x1428b70c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaSession::SetOption, WmeSessionOption_Enable_Sending_CSRC, bSendingCSRC = 1, m_eSessionType = 0, result = 0 [this=0x140725680]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaSession::SetOption, WmeSessionOption_EnableRTXLongDelayTolerantOptmization= 0, m_eSessionType = 0 [this=0x140725680]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaSession::SetOption, WmeSessionOption_EnableBandwidthRollback, bEnableRollback = 1, m_eSessionType = 0 [this=0x140725680]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[RTP] CRTPSessionClientAudio_A141852::CRTPSessionClient::EnableMultiSSRCforSRTP enabled = 0 [this=0x1428b70c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaSession::SetOption, WmeSessionOption_EnableMultiSSRCforSRTP, bEnableMultiSSRCforSRTP = 0, m_eSessionType = 0 [this=0x140725680]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CreateMediaDevicesNotifier,line=670 [cid=3691033875] [this=0x140725440] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::InitAudioEnvironment,line=1849 [cid=3691033875] [this=0x140725440] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::InitAudioEngine,line=1720 [cid=3691033875] [this=0x140725440] Enter..., g_bEnableGlobalAudioDeviceEnum=1"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineWrapperManager::CreateAudioEngineWrapper() [cid=3691033875] [this=0x6000001551f0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineWrapperManager::CreateAudioEngineWrapper() create new one! [cid=3691033875] [this=0x6000001551f0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineWrapper::CWbxAudioEngineWrapper() [cid=3691033875] [this=0x60000042d900]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.061Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineWrapper::Initialize() Default Sample Rate = 48000 [cid=3691033875] [this=0x60000042d900]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.062Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc dolphin::AudioDeviceManager::AudioDeviceManager,line=181 [cid=4294967295] [this=0x1204e8618] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.062Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc dolphin::AudioDeviceManager::AudioDeviceManager,line=181 [cid=4294967295] [this=0x1204e8618] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.062Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]AudioChannelManagerImpl::AudioChannelManagerImpl() [cid=3691033875] [this=0x1204ee190]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.062Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.062Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.062Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.062Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::CWbxAudioEngineImpl, end,  m_nSamplerate:48000 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer]Create an audio engine instance, instance = 0x1204e8600, Fs = 48000, version = 2.0 [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableFixedAudioProcessingArch() had expired from wme 8.5.0!! [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]AudioDeviceManager::SetVPIOEnable,  bEnabled:0. [cid=3691033875] [this=0x1204e8618]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableReserveDelayForRTX(), m_enableReserverDelayForRTX:-1 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::Init(), begin [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141039a00] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141039a00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141039a00] Enter..., aType=-1, aFlag=1, Register=1, name=a-engine"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] thread type is TT_UNKNOWN"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x1708b3000 [this=0x141039a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=a-engine, m_Tid=0x1708b3000 [this=0x141039a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CCmThreadTask::OnThreadRun, Begin. name=a-engine [this=0x141039a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x141039a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] RegisterThread, thread=0x141039a00 tid=0x1708b3000 name=a-engine type=-1 eventQueue=0x141039d08 timerQueue=0x140624f90"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141039a00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::CreateDispatcher(), CreateUserTaskThread() success, dispatcher_ = 0x141039a00 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x14109dc00] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x14109dc00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x14109dc00] Enter..., aType=-1, aFlag=1, Register=1, name=a-engine-onidle"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] thread type is TT_UNKNOWN"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x17093f000 [this=0x14109dc00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10e]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=a-engine-onidle, m_Tid=0x17093f000 [this=0x14109dc00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10e]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CCmThreadTask::OnThreadRun, Begin. name=a-engine-onidle [this=0x14109dc00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x14109dc00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] RegisterThread, thread=0x14109dc00 tid=0x17093f000 name=a-engine-onidle type=-1 eventQueue=0x14109df08 timerQueue=0x1406251d0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x14109dc00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::CreateDispatcher(), CreateUserTaskThread() success, OnIdle = 0x14109dc00 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::_init(), begin [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::CleanAudioEngineSinkList  [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::subscribeConfig, Audio, xcodec_model_path, 4, m_TotalObservers=3, pRunThread=0x0, bAsync=1 [cid=0] [this=0x14080e200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::_init, set xcodec path = ********/Library/Application Support/Cisco Spark/Webexteams_upgrades_arm/45.1.0.31546_604bd55d-9d56-4040-a185-a7063dfb3aec/dynamic_components/xcodec [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::subscribeConfig, Audio, wmos_model_path, 5, m_TotalObservers=4, pRunThread=0x0, bAsync=1 [cid=0] [this=0x14080e200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::WmeConfig::subscribeConfig, Audio, XNNEngine_lib_path, 6, m_TotalObservers=5, pRunThread=0x0, bAsync=1 [cid=0] [this=0x14080e200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.063Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc dolphin::AudioDeviceManager::_init,line=380 [cid=3691033875] [this=0x1204e8618] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.064Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AudioDeviceEnumerator(). [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.064Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::WBXDeviceEnumeratorMac() Begin! [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.064Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 1 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.064Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer]Device enumerator pointer = 0x142224a00 [cid=3691033875] [this=0x1204e8618]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.064Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] AudioDeviceEnumerator::AddDispatcher(), dispatcher:0x1204e8620 [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.064Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::Init() Begin,,m_bInited:0 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.064Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] WBXDeviceChangeListenerMac::AddDeviceEnumeratorObserver(),pDeviceEnu:0x142224a00 [this=0x107b11b48]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.064Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetAllHALdevs() List device info name = *ac*oo* P*o *ic*op*one and UID = BuiltInMicrophoneDevice audioDeviceId = 98 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.065Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetAllHALdevs() List device info name = *ac*oo* P*o *pe*ke*s and UID = BuiltInSpeakerDevice audioDeviceId = 91 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.066Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetAllHALdevs() List device info name = *ic*os*ft*Te*ms*Au*io and UID = MSLoopbackDriverDevice_UID audioDeviceId = 81 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.067Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetAllHALdevs() List device info name = *eb*xM*di*Au*io*ev*ce and UID = com.cisco.wme.pluginaudio audioDeviceId = 74 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDeviceInfo() [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Error",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::ConvTransTypeToDeviceType, Error getting the datasource of the built-in audio device to determine whether it's loudspeaker or headphones err=2003332927 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDeviceIDByUID() AudioObjectGetPropertyData error = 0 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDefaultSampleRateByUID,the samplate:48000.000 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDeviceInfo() [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::ConvTransTypeToDeviceType, detected internal louspeaker NOT minijack headphones [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDeviceIDByUID() AudioObjectGetPropertyData error = 0 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDefaultSampleRateByUID,the samplate:48000.000 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDeviceInfo() [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDeviceIDByUID() AudioObjectGetPropertyData error = 0 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDefaultSampleRateByUID,the samplate:48000.000 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDeviceInfo() [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDeviceIDByUID() AudioObjectGetPropertyData error = 0 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDefaultSampleRateByUID,the samplate:48000.000 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::PrintDevice, there are 2 input devices, and there are 2 output devices in the system. [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][DeviceEnumerator][Capture][DeviceInformation] There are 2 capture device, the 0 device is: flow = 0, dwWaveID = 98, sFriendlyName = *ac*oo* P*o *ic*op*one, sCoreID = BuiltInMicrophoneDevice, sGUID = , sInterfaceID = m [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][DeviceEnumerator][Capture][DeviceInformation] There are 2 capture device, the 1 device is: flow = 0, dwWaveID = 81, sFriendlyName = *ic*os*ft*Te*ms*Au*io, sCoreID = MSLoopbackDriverDevice_UID, sGUID = , sInterfaceID = s [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][DeviceEnumerator][Playback][DeviceInformation] There are 2 playback device, the 0 device is: flow = 1, dwWaveID = 91, sFriendlyName = *ac*oo* P*o *pe*ke*s, sCoreID = BuiltInSpeakerDevice, sGUID = , sInterfaceID = s [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][DeviceEnumerator][Playback][DeviceInformation] There are 2 playback device, the 1 device is: flow = 1, dwWaveID = 81, sFriendlyName = *ic*os*ft*Te*ms*Au*io, sCoreID = MSLoopbackDriverDevice_UID, sGUID = , sInterfaceID = s [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::Init() End. [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::RegisterNotification(), pSink=0x1204e8638, list size=0 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 2 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc dolphin::AudioDeviceManager::_init,line=380 [cid=3691033875] [this=0x1204e8618] Leave, cost=5ms"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10e]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::Release(), Reference count = 2 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10e]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::RegisterNotification(),async push to Observer list, pSink=0x1204e8638 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::_initAQE() with aqerefine, begin [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.068Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::_initAQE(), GetFeatureToggle, WME_FT_EnableWMEAudioAcmThreadAsync = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.069Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] ArrayBase::ResetChannelSelect [this=0x140939818]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.069Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.069Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.069Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] AudioShareChannelImpl audio_cupid_ = 0x1204e8000 [this=0x140936e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.069Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]AudioShareChannelImpl::AudioShareChannelImpl() end.fs=48000 [cid=3691033875] [this=0x140936e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.069Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.069Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.069Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]AudioRecordChannelImpl::AudioRecordChannelImpl() end. [cid=3691033875] [this=0x1410d7400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.069Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.069Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.069Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]AudioPlaybackChannelImpl::AudioPlaybackChannelImpl() [cid=3691033875] [this=0x1410de600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer]audio_stream_encode_channel_ pointer = 0x1410e6800 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer]sharing_channel pointer = 0x140936e00 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer]record_channel pointer = 0x1410d7400 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer]playback_channel pointer = 0x1410de600 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer]audio_bus_service pointer = 0x60000285b100 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AudioResampleComponent::AudioResampleComponent(), success., this=0x6000025903f0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][StreamAdapter] create resample pointer = 0x6000025903f0 [this=0x14109f200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][StreamAdapter] Init success. [this=0x14109f200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x140725ac0] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x140725ac0] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x140725ac0] Enter..., aType=1, aFlag=1, Register=0, name=a-enc"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x1709cb000 [this=0x140725ac0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10f]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=a-enc, m_Tid=0x1709cb000 [this=0x140725ac0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10f]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeEncoderThread::OnThreadInit, thread policy = 1 [cid=3691033875] [this=0x140725ac0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10f]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeEncoderThread::OnThreadInit, Priority [15,47] from 31 to 47; Current policy = 1 [cid=3691033875] [this=0x140725ac0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x140725ac0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x140725ac0] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeRecordChannel::CreateEncodethread(), create encdoer thread :0x140725ac0 [cid=3691033875] [this=0x142909200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeRecordChannel::CWbxAeRecordChannel(), end.Encoder thread: 0x140725ac0, m_dwLastIncreaseTC:1870344486, m_dwResetTC:3877189408 [cid=3691033875] [this=0x142909200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AudioResampleComponent::AudioResampleComponent(), success., this=0x6000025e0090"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][StreamAdapter] create resample pointer = 0x6000025e0090 [this=0x141105c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][StreamAdapter] Init success. [this=0x141105c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][FarendVoiceCancell processing] create aec pointer = 0x6000009d2e40 [this=0x141109c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.070Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] AAEC, CreateIAECInst, Fs:48000, fftlen_ms:16.000, framlen_ms:10.000, Valu0dB:1.000"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AEC component-create alpha_aec instance, pointer = 0x600000e19920, it's a AAEC. [this=0x6000009d2e40]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][FarendVoiceCancell processing] create dagc pointer = 0x600000436a80 [this=0x141109c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][FarendVoiceCancell processing] Init success. [this=0x141109c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AECReferencBuf::AECReferencBuf(), max_buffer_size = 10, sizeof(AudioFrame) = 11572, this=0x141151c00"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AECReferencBuf::Reset(), success. Previous state = 2, this=0x141151c00"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AECReferencBuf::AECReferencBuf(), max_buffer_size = 10, sizeof(AudioFrame) = 11572, this=0x141154a00"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AECReferencBuf::Reset(), success. Previous state = 2, this=0x141154a00"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AECReferencBuf::AECReferencBuf(), max_buffer_size = 15, sizeof(AudioFrame) = 11572, this=0x141157800"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer]sharing_channel-reference buffer pointer = 0x141157800 [cid=3691033875] [this=0x140936e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AECReferencBuf::Reset(), success. Previous state = 2, this=0x141157800"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x140726630] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x140726630] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x140726630] Enter..., aType=1, aFlag=1, Register=0, name=a-enc"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x170a57000 [this=0x140726630]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a110]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=a-enc, m_Tid=0x170a57000 [this=0x140726630]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a110]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeEncoderThread::OnThreadInit, thread policy = 1 [cid=3691033875] [this=0x140726630]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a110]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeEncoderThread::OnThreadInit, Priority [15,47] from 31 to 47; Current policy = 1 [cid=3691033875] [this=0x140726630]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x140726630]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x140726630] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeRecordChannel::CreateEncodethread(), create encdoer thread :0x140726630 [cid=3691033875] [this=0x14115a600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.071Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeRecordChannel::CWbxAeRecordChannel(), end.Encoder thread: 0x140726630, m_dwLastIncreaseTC:1870344487, m_dwResetTC:3877189456 [cid=3691033875] [this=0x14115a600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.072Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeRecordChannel::SetDelaySwitchConfig(), payload type = 101, isDelay = 0 [cid=3691033875] [this=0x14115a600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.072Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioChannel::SetCodecInst, return is 0 [cid=3691033875] [this=0x14115a600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngineCodec] [CheckPoint][AudioCodec][EncoderSettings]codecname = [Opus], FECEnabled = 1, VadEnabled = 0, EncodeBitrate = 60000,  EncodeComplex = 5, FrameInterval = 20, InputBitsPerSample = 16, InputChannelNumber = 1, InputSampleRate = 48000, maxInternalSampleRate = 24000, VBR = 1, result = 0, version:libopus 1.3.1 [this=0x600001b6c140] [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioChannel::updateSendCodecInfoToMediaStores begin, callId = 0, sessionType = 15 [cid=3691033875] [this=0x14115a600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioChannel::updateSendCodecInfoToMediaStores begin, callId = 0, sessionType = 15 [cid=3691033875] [this=0x14115a600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AudioResampleComponent::AudioResampleComponent(), success., this=0x6000025e02d0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][StreamAdapter] create resample pointer = 0x6000025e02d0 [this=0x14117ca00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][StreamAdapter] Init success. [this=0x14117ca00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][record processing], create RecordAudioProcessing instance, fs:48000, frame_size_in_sample:480 [cid=3691033875] [this=0x141180a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][record processing] create sa pointer = 0x60000016ab50 [cid=3691033875] [this=0x141180a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][SA component]--create sa instance, pointer = 0x6000009d29e0 [this=0x60000016ab50]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][record processing] create aec pointer = 0x6000009ce580 [cid=3691033875] [this=0x141180a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] AAEC, CreateIAECInst, Fs:48000, fftlen_ms:16.000, framlen_ms:10.000, Valu0dB:1.000"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AEC component-create alpha_aec instance, pointer = 0x600000e60420, it's a AAEC. [this=0x6000009ce580]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][record processing] create nova_aec pointer = 0x600000e624c0 [cid=3691033875] [this=0x141180a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.073Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][record processing] create dagc pointer = 0x600000464880 [cid=3691033875] [this=0x141180a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][record processing] create aagc pointer = 0x600000e1a6a0 [cid=3691033875] [this=0x141180a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][record processing] Init success. [cid=3691033875] [this=0x141180a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AECReferencBuf::AECReferencBuf(), max_buffer_size = 3, sizeof(AudioFrame) = 11572, this=0x1411f9e00"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer]record_channel-reference buffer pointer = 0x1411f9e00, ref_size:3 [cid=3691033875] [this=0x1410d7400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AECReferencBuf::Reset(), success. Previous state = 2, this=0x1411f9e00"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x140726c20] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x140726c20] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x140726c20] Enter..., aType=1, aFlag=1, Register=0, name=a-enc"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x170ae3000 [this=0x140726c20]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a112]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=a-enc, m_Tid=0x170ae3000 [this=0x140726c20]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a112]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeEncoderThread::OnThreadInit, thread policy = 1 [cid=3691033875] [this=0x140726c20]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a112]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeEncoderThread::OnThreadInit, Priority [15,47] from 31 to 47; Current policy = 1 [cid=3691033875] [this=0x140726c20]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x140726c20]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x140726c20] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeRecordChannel::CreateEncodethread(), create encdoer thread :0x140726c20 [cid=3691033875] [this=0x1411fcc00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeRecordChannel::CWbxAeRecordChannel(), end.Encoder thread: 0x140726c20, m_dwLastIncreaseTC:1870344490, m_dwResetTC:3877189600 [cid=3691033875] [this=0x1411fcc00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AudioResampleComponent::AudioResampleComponent(), success., this=0x6000025e03c0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][StreamAdapter] create resample pointer = 0x6000025e03c0 [this=0x14121f600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][StreamAdapter] Init success. [this=0x14121f600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AudioResampleComponent::AudioResampleComponent(), success., this=0x6000025e3ea0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][StreamAdapter] create resample pointer = 0x6000025e3ea0 [this=0x141220c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][StreamAdapter] Init success. [this=0x141220c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][playback processing], create PlaybackAudioProcessing instance, fs:48000, frame_size_in_sample:480 [cid=3691033875] [this=0x141227600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][playback processing], create PlaybackAudioProcessing instance, fs:48000, frame_size_in_sample:480 [cid=3691033875] [this=0x14122da00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][playback processing] create mixer pointer = 0x600002a9b8c0 [cid=3691033875] [this=0x141227600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][mixer component]create mixer instance, pointer = 0x600000e10360 [this=0x600002a9b8c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][mixer component]create mixer instance, pointer = 0x600000e103c0 [this=0x600002a9a8c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] AAEC, CreateIAECInst, Fs:48000, fftlen_ms:8.000, framlen_ms:3.333, Valu0dB:1.000"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AEC component-create alpha_aec instance, pointer = 0x600000e10480, it's a AAEC. [this=0x6000009d3f70]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][playback processing] create nr pointer = 0x6000009d3f70 [cid=3691033875] [this=0x141227600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][playback processing] enable playback eq =1 [cid=3691033875] [this=0x141227600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][playback processing] create dagc pointer = 0x600000436900 [cid=3691033875] [this=0x141227600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][playback processing] Int success. [cid=3691033875] [this=0x141227600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][playback processing] create mixer pointer = 0x600002a9b660 [cid=3691033875] [this=0x14122da00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][mixer component]create mixer instance, pointer = 0x600000e104e0 [this=0x600002a9b660]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer][mixer component]create mixer instance, pointer = 0x600000e10540 [this=0x600002a9b800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] AAEC, CreateIAECInst, Fs:48000, fftlen_ms:8.000, framlen_ms:3.333, Valu0dB:1.000"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]AEC component-create alpha_aec instance, pointer = 0x600000e10600, it's a AAEC. [this=0x6000009d38e0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][playback processing] create nr pointer = 0x6000009d38e0 [cid=3691033875] [this=0x14122da00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][playback processing] enable playback eq =1 [cid=3691033875] [this=0x14122da00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][playback processing] create dagc pointer = 0x600000436e80 [cid=3691033875] [this=0x14122da00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.074Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer][playback processing] Int success. [cid=3691033875] [this=0x14122da00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] AudioSystemVolumeAutoAdjust::LockSink, m_nRefCount:1 [this=0x140928000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] AudioQualityAssessment::AudioQualityAssessment() success. [this=0x600000e10780]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] AudioRealtimeStatusParsing::AudioRealtimeStatusParsing() success, metrics inst =0x140932000 [this=0x141332400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141332c00] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141332c00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141332c00] Enter..., aType=-1, aFlag=1, Register=1, name=urt-proc"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Warn",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] thread type is TT_UNKNOWN"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x170b6f000 [this=0x141332c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a113]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=urt-proc, m_Tid=0x170b6f000 [this=0x141332c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a113]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CCmThreadTask::OnThreadRun, Begin. name=urt-proc [this=0x141332c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x141332c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] RegisterThread, thread=0x141332c00 tid=0x170b6f000 name=urt-proc type=-1 eventQueue=0x141332f08 timerQueue=0x14072b470"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141332c00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141333200] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141333200] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141333200] Enter..., aType=-1, aFlag=1, Register=1, name=urt-proc"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Warn",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] thread type is TT_UNKNOWN"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x170bfb000 [this=0x141333200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a114]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=urt-proc, m_Tid=0x170bfb000 [this=0x141333200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a114]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CCmThreadTask::OnThreadRun, Begin. name=urt-proc [this=0x141333200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x141333200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] RegisterThread, thread=0x141333200 tid=0x170bfb000 name=urt-proc type=-1 eventQueue=0x141333508 timerQueue=0x14072b6b0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141333200] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141333800] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141333800] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141333800] Enter..., aType=-1, aFlag=1, Register=1, name=urt-proc"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Warn",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] thread type is TT_UNKNOWN"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x170c87000 [this=0x141333800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a115]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=urt-proc, m_Tid=0x170c87000 [this=0x141333800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a115]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CCmThreadTask::OnThreadRun, Begin. name=urt-proc [this=0x141333800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x141333800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] RegisterThread, thread=0x141333800 tid=0x170c87000 name=urt-proc type=-1 eventQueue=0x141333b08 timerQueue=0x141836520"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141333800] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141333e00] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141333e00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a115]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] AudioQualityAssessment::OnStart() success. [this=0x600000e10780]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141333e00] Enter..., aType=-1, aFlag=1, Register=1, name=urt-proc"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Warn",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] thread type is TT_UNKNOWN"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x170d13000 [this=0x141333e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a116]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=urt-proc, m_Tid=0x170d13000 [this=0x141333e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a116]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CCmThreadTask::OnThreadRun, Begin. name=urt-proc [this=0x141333e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x141333e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] RegisterThread, thread=0x141333e00 tid=0x170d13000 name=urt-proc type=-1 eventQueue=0x141334108 timerQueue=0x141836760"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141333e00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetSysDefaultMicrophone() begin [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Info",
+        "thread ID": "[0xd2a116]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] AudioRealtimeStatusParsing::OnStart() success. [this=0x141332400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.075Z",
+        "level": "Error",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::ConvTransTypeToDeviceType, Error getting the datasource of the built-in audio device to determine whether it's loudspeaker or headphones err=2003332927 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetSysDefaultMicrophone() FriendlyName is *ac*oo* P*o *ic*op*one halID is BuiltInMicrophoneDevice [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDeviceIDByUID() AudioObjectGetPropertyData error = 0 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetDefaultSampleRateByUID,the samplate:48000.000 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][DeviceEnumerator][Capture][DefaultDevice]Default capture device's name is *ac*oo* P*o *ic*op*one, type is 1 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetSysDefaultSpeaker(), default id:0 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetSysDefaultSpeaker(), usedID:91 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::ConvTransTypeToDeviceType, detected internal louspeaker NOT minijack headphones [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]WBXDeviceEnumeratorMac::GetSysDefaultSpeaker() FriendlyName is *ac*oo* P*o *pe*ke*s halID is BuiltInSpeakerDevice [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][DeviceEnumerator][Playback][DefaultDevice]Default playback device's name is *ac*oo* P*o *pe*ke*s, type is 1 [cid=3691033875] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc *dolphin::AudioDeviceManager::_createDeviceEngine,line=710 [cid=3691033875] [this=0x1204e8618] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] ArrayBase::ResetChannelSelect [this=0x141335c98]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::CWbxAeAudioCapture() audio_cupid = 0x1204e8000 [cid=3691033875] [this=0x141334400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::CWbxAeAudioCapture() end!, nChannels:1, nSamplesPerSec:8000, wBitsPerSample:16, nBlockAlign:2 [cid=3691033875] [this=0x141334400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::Init(), begin [cid=3691033875] [this=0x141334400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141335e00] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x141335e00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141335e00] Enter..., aType=-1, aFlag=1, Register=1, name=a-capture"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Warn",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] thread type is TT_UNKNOWN"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x170d9f000 [this=0x141335e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a117]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=a-capture, m_Tid=0x170d9f000 [this=0x141335e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a117]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CCmThreadTask::OnThreadRun, Begin. name=a-capture [this=0x141335e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x141335e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] RegisterThread, thread=0x141335e00 tid=0x170d9f000 name=a-capture type=-1 eventQueue=0x141336108 timerQueue=0x141a17c00"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x141335e00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::Init, CreateUserTaskThread success, m_pDispatcher = 0x141335e00 [cid=3691033875] [this=0x141334400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]: callID = 3691033875,WbxAeAudioCapturePlatformMac::WbxAeAudioCapturePlatformMac End [this=0x141336400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::Init(), raw_data_broadcaster_ = 0x14072b8f0 [cid=3691033875] [this=0x141334400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::Init(), End [cid=3691033875] [this=0x141334400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::SetMetricsSink() pSink = 0x1204e8628 [cid=3691033875] [this=0x141334400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] CaptureMetricManager::SetMetricsDataSink() pSink = 0x1204e8628 [this=0x141336438]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::SetErrorMessageSink()  = 0x1204e8630 [cid=3691033875] [this=0x141334400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::SetDevice() [cid=3691033875] [this=0x141334400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::_setDevice() begin. pDeviceID = << 0x141334458,  pFormat = 0x141334438,ChannelNum = 1, SamplesPerSec = 48000, BitsPerSample = 16 [cid=3691033875] [this=0x141334400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]: callID = 3691033875,,WbxAeAudioCapturePlatformMac::PrintDevice() ,flow:0,dwWaveID:98,sFriendlyName:*ac*oo* P*o *ic*op*one,sCoreID:BuiltInMicrophoneDevice,sGUID:,sInterfaceID: [this=0x141336400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]: callID = 3691033875,WbxAeAudioCapturePlatformMac::SetDevice, m_RecordChannel is NULL [this=0x141336400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Capture]Set Device, origin device name is *,  it wants to set to *ac*oo* P*o *ic*op*one , result is 0 [cid=3691033875] [this=0x141336400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc *dolphin::AudioDeviceManager::_createDeviceEngine,line=710 [cid=3691033875] [this=0x1204e8618] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc *dolphin::AudioDeviceManager::_createDeviceEngine,line=710 [cid=3691033875] [this=0x1204e8618] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioPlayback::Init(), begin [cid=3691033875] [this=0x1480f8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioPlayback::SetRingtoneDataProvider() Provider = 0x0 [cid=3691033875] [this=0x1480f8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x14291e000] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x14291e000] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x14291e000] Enter..., aType=-1, aFlag=1, Register=1, name=a-playback"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Warn",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] thread type is TT_UNKNOWN"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x170e2b000 [this=0x14291e000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a118]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=a-playback, m_Tid=0x170e2b000 [this=0x14291e000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a118]",
+        "messages": [
+            "[]WME:0 ::[UTIL] CCmThreadTask::OnThreadRun, Begin. name=a-playback [this=0x14291e000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x14291e000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] RegisterThread, thread=0x14291e000 tid=0x170e2b000 name=a-playback type=-1 eventQueue=0x14291e308 timerQueue=0x14072ba50"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x14291e000] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.076Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioPlayback::Init, CreateUserTaskThread success, m_pDispatcher = 0x14291e000 [cid=3691033875] [this=0x1480f8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]: callID = 3691033875,WbxAeAudioPlaybackPlatformMac::WbxAeAudioPlaybackPlatformMac End! [this=0x1440e2200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioPlayback::Init() [cid=3691033875] [this=0x1480f8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioPlayback::Init(), End [cid=3691033875] [this=0x1480f8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioPlayback::SetMetricsSink() pSink = 0x1204e8628 [cid=3691033875] [this=0x1480f8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]PlaybackMetricManager::SetMetricsDataSink() pSink = 0x1204e8628 [cid=3691033875] [this=0x1440e2240]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioPlayback::SetErrorMessageSink()  = 0x1204e8630 [cid=3691033875] [this=0x1480f8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioPlayback::SetDevice() [cid=3691033875] [this=0x1480f8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioPlayback::_setDevice() want format samplerate = 48000channels = 1averatgebytes = 96000format tag = 0wBitsPerSample = 16 [cid=3691033875] [this=0x1480f8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]: callID = 3691033875,WbxAeAudioPlaybackPlatformMac::PrintDevice() ,flow:1,dwWaveID:91,sFriendlyName:*,sCoreID:BuiltInSpeakerDevice,sGUID:,sInterfaceID: [this=0x1440e2200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Playback]Set Device, origin device name is *ac*oo* P*o *pe*ke*s,  it wants to set to * , result is 0 [cid=3691033875] [this=0x1440e2200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc *dolphin::AudioDeviceManager::_createDeviceEngine,line=710 [cid=3691033875] [this=0x1204e8618] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc *dolphin::AudioDeviceManager::_createDeviceEngine,line=710 [cid=3691033875] [this=0x1204e8618] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] ArrayBase::ResetChannelSelect [this=0x141339498]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::CWbxAeAudioCapture() audio_cupid = 0x1204e8000 [cid=3691033875] [this=0x141337c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::CWbxAeAudioCapture() end!, nChannels:1, nSamplesPerSec:8000, wBitsPerSample:16, nBlockAlign:2 [cid=3691033875] [this=0x141337c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] CWbxAeAudioExternalCapture::CWbxAeAudioExternalCapture() [this=0x141337c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioExternalCapture::Init() [cid=3691033875] [this=0x141337c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::SetMetricsSink() pSink = 0x1204e8628 [cid=3691033875] [this=0x141337c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioCapture::SetErrorMessageSink()  = 0x1204e8630 [cid=3691033875] [this=0x141337c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc *dolphin::AudioDeviceManager::_createDeviceEngine,line=710 [cid=3691033875] [this=0x1204e8618] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc *dolphin::AudioDeviceManager::_createDeviceEngine,line=710 [cid=3691033875] [this=0x1204e8618] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioExternalPlayback::CWbxAeAudioExternalPlayback() [cid=3691033875] [this=0x141339600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioExternalPlayback::Init() [cid=3691033875] [this=0x141339600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioExternalPlayback::SetMetricsSink() pSink = 0x1204e8628 [cid=3691033875] [this=0x141339600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAeAudioExternalPlayback::SetDevice() want format, samplerate = 48000, channels = 1, averatgebytes = 96000, format tag = 0, wBitsPerSample = 16 [cid=3691033875] [this=0x141339600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc *dolphin::AudioDeviceManager::_createDeviceEngine,line=710 [cid=3691033875] [this=0x1204e8618] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]playback_channel-reference buffer pointer = 0x1411f9e00 [this=0x1410de600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]when sharing, reference buffer pointer for record channel = 0x1411f9e00 [this=0x140936e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [CheckPoint][Audio][SubmodulePointer]playback_channel-for sharing reference bufferpointer = 0x141157800 [this=0x1410de600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]AudioChannelManagerImpl::Init() [cid=3691033875] [this=0x1204ee190]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio]AudioChannelManagerImpl::SetAudioSharingECStatus()  AudioSharingAEC enable = 0 [cid=3691033875] [this=0x1204ee190]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::CreateAllPlaybackChannel(), begin, aqerefine = 1 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x141356400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x1418369a0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x1418369a0, jitterPolicy:0x600001575950 [this=0x141356400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x1418369a0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f53c40]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f53d00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f53cc0 [this=0x141356400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x141356400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x141372600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x14072bfb0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x14072bfb0, jitterPolicy:0x600001575680 [this=0x141372600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x14072bfb0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f53f40]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f53280]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f53240 [this=0x141372600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x141372600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x14138e800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x14072c510]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x14072c510, jitterPolicy:0x600001577660 [this=0x14138e800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x14072c510]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f53ac0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f51540]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f51500 [this=0x14138e800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x14138e800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x1413aaa00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x14072ca70]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x14072ca70, jitterPolicy:0x600001577cf0 [this=0x1413aaa00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x14072ca70]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f51780]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f51840]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f51800 [this=0x1413aaa00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x1413aaa00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x1413c6c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x14072cfd0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x14072cfd0, jitterPolicy:0x60000154bed0 [this=0x1413c6c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x14072cfd0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f51a80]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f51b40]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f51b00 [this=0x1413c6c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x1413c6c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x1413e2e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x14072d530]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x14072d530, jitterPolicy:0x6000015490e0 [this=0x1413e2e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x14072d530]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f51d80]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f51e40]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f51e00 [this=0x1413e2e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x1413e2e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x1413ff000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x14072da90]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x14072da90, jitterPolicy:0x60000154b390 [this=0x1413ff000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x14072da90]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f52080]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f52140]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f52100 [this=0x1413ff000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.077Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x1413ff000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x14141b200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x14072dff0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x14072dff0, jitterPolicy:0x60000154afd0 [this=0x14141b200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x14072dff0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f522c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f52380]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f52340 [this=0x14141b200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x14141b200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x141437400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x14072e550]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x14072e550, jitterPolicy:0x600001549860 [this=0x141437400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x14072e550]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f525c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f52680]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f52640 [this=0x141437400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x141437400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x141453600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x14072eab0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x14072eab0, jitterPolicy:0x60000155a940 [this=0x141453600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x14072eab0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f513c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f528c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f52880 [this=0x141453600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x141453600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x14146f800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x14072f010]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x14072f010, jitterPolicy:0x600001559770 [this=0x14146f800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x14072f010]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f52b00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f52bc0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f52b80 [this=0x14146f800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x14146f800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x14148ba00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x14072f570]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x14072f570, jitterPolicy:0x60000155b930 [this=0x14148ba00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x14072f570]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f52e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f52ec0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f52e80 [this=0x14148ba00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x14148ba00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x1414a7c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x14072fad0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x14072fad0, jitterPolicy:0x60000155a580 [this=0x1414a7c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x14072fad0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f53040]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f53100]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f530c0 [this=0x1414a7c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x1414a7c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x1414c3e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x140730030]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x140730030, jitterPolicy:0x600001577c00 [this=0x1414c3e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x140730030]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f762c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f76380]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f76340 [this=0x1414c3e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x1414c3e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x1414e1000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x140730590]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x140730590, jitterPolicy:0x6000015772a0 [this=0x1414e1000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x140730590]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f765c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f76680]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f76640 [this=0x1414e1000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x1414e1000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x14304dc00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x141836be0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x141836be0, jitterPolicy:0x6000015181e0 [this=0x14304dc00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x141836be0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f56e00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f55480]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f55440 [this=0x14304dc00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x14304dc00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x143073600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x141cbc120]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x141cbc120, jitterPolicy:0x600001518c30 [this=0x143073600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x141cbc120]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f550c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.078Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f553c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f55380 [this=0x143073600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x143073600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x144246c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x141d1b200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x141d1b200, jitterPolicy:0x60000151c2d0 [this=0x144246c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x141d1b200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f4c040]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f4d600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f4d5c0 [this=0x144246c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x144246c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x14426a200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x141d1b440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x141d1b440, jitterPolicy:0x60000156cd20 [this=0x14426a200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x141d1b440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f4f100]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f4e8c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f4e880 [this=0x14426a200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x14426a200]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  begin! [this=0x144286400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::Reset() [this=0x141d1b9a0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer create jitter policy success, enableDelayEstimation:1, delayEstimation:0x141d1b9a0, jitterPolicy:0x60000156d770 [this=0x144286400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] DelayEstimation::SetDelay(), nMinDelay:30, nMaxDelay:2200 [this=0x141d1b9a0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f4dd80]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:BurstDetector::Init , m_frameInterval:20, burstTimestamp:0, burstLevel:0, level1:100 2, level2:160 1.6, level3:240 1.6 [this=0x600001f4e740]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::CAudioJitterBuffer(),  :0,enableCacheByRtpTimestamp:1 ,m_packetCache:0x600001f4e700 [this=0x144286400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] wmeStore::CreateWmeConfig [cid=3691033875]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [AJB buffer]:CAudioJitterBuffer::EnableReserveDelayForRTX,value:-1 [this=0x144286400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::CreateAllPlaybackChannel(), end, aqerefine = 1 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]SetAECStatus, enable = 1, result = 0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer]AudioRecordChannelImpl::SetAEC_NREnable AEC_NR = 0; BNR = 0; BNR Talker Mode = 0; MusicMode = 0 [cid=3691033875] [this=0x1410d7400]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]SetNSStatus, enable=0;result = 0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]SetMicrophoneDAGC, enable=0, type=0, result = 0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]SetMicrophoneAAGC, enable=1, result = 0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::SetSpeakerAGCStatus, enable=0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]SetSpeakerDAGC, enable=0, type=0, result = 0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::_initAQE() with aqerefine, end [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::GetPlaybackCNG, enable=1 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x1389b8018] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.079Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::ACmThread,line=44 [this=0x1389b8018] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=0]QoEM:QoEM_Measure:Total initial QoE Data Blocks:10 [cid=0] [this=0x120018000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=0]QoEM:created [cid=0] [this=0x120018000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x1389b8018] Enter..., aType=1, aFlag=1, Register=0, name=QoEM"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::Create, thread succeed, m_Tid=0x170eb7000 [this=0x1389b8018]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a11e]",
+        "messages": [
+            "[]WME:0 ::[UTIL] ACmThread::threadProc begin, m_name=QoEM, m_Tid=0x170eb7000 [this=0x1389b8018]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] SetPriority() Priority = 2147483647 [this=0x1389b8018]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a11e]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=0]QoEM:QoEM_MonitorProcess::OnThreadRun: Enter thread-12-22-15  [cid=0] [this=0x120018000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc ACmThread::Create,line=92 [this=0x1389b8018] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::_init(), end, interal sample rate:48000, capture sample rate:48000, playback sample rate:48000 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::Init(), end [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::GetSpeakerAGCStatus, enable=0, type=0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::InitAudioEngine SetSpeakerDAGCStatus status = 0, type = 0 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::GetMicAGCStatus, enabled=0, mode=1, type=0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]SetMicrophoneDAGC, enable=1, type=0, result = 0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::InitAudioEngine SetMicDAGCStatus status = 1, type = 0 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::RestoreOptions,line=1823 [cid=3691033875] [this=0x140725440] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]CWbxAudioEngineImpl::EnablePlaybackCNG, enable=1, result = 0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::SetBypassPlaybackNR, enable=0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::SetStereoTSMStatus, enable=0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]SetStereoTSMStatus, enable=0, ret=0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::GetAudioSPCStatus(), nStatus = -1 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::GetAudioSPCStatus(), nStatus = -1 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::GetAudioStaticPerfLevel, Level =-1; SPC Status = -1 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::GetAudioSPCStatus(), nStatus = -1 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::SetAudioStaticPerfLevel, Level =4;SPC Status = -1 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::SetRxCallBNRStatus, enable=0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer]AudioPlaybackChannelImpl::SetAEC_NREnable AEC_NR = 1; BypassPlaybackNR = 0; RX BNR = 0; MusicMode = 0; RX SpeechEnhancements = 0 [cid=3691033875] [this=0x1410de600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]SetRxCallBNRStatus, enable=0, ret=0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]SetRxCapabilityBNRStatus, enable=0, ret=0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]SetRxCapabilityBWEStatus, enable=0, ret=0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Audio][SubmodulePointer]AudioPlaybackChannelImpl::SetAEC_NREnable AEC_NR = 1; BypassPlaybackNR = 0; RX BNR = 0; MusicMode = 0; RX SpeechEnhancements = 0 [cid=3691033875] [this=0x1410de600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]CWbxAudioEngineImpl::SetRxSpeechEnhancementsStatus, enable=0, ret=0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::SetAdaptiveAudioBandwidth(), enable:1, minBW:26000, maxBW:60000 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]EnableBypassWindowsAPOAllowList, m_bBypassWindowsAPOAllowListEnabled = 0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]SetStereoContentAudioStatus, m_bShareStereoEnabled = 0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::RestoreOptions,line=1823 [cid=3691033875] [this=0x140725440] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::SetOption, option = 1001, value = 1 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::SetOption, option = 1002, value = 0, res = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableAutoAudioDucking(), Ducking = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=0, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=1, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=2, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=3, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=4, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=5, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=6, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=7, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=8, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=9, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=10, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=11, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=12, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=13, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=14, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=15, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=16, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=17, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=18, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::EnableUnderrunPLC, m_pPlaybackChannel=19, enabled = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::SetOption, option = 1003, value = 0, res = 0 [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::InitAudioEngine, end [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::InitAudioEngine,line=1720 [cid=3691033875] [this=0x140725440] Leave, cost=19ms"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]CWbxAudioEngineImpl::GetSeperateSessionCtrlEnable, no implement on other OS! [cid=3691033875] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 2 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 3 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875][CheckPoint][Settings]GetCaptureRawDataStatus, m_bCaptureRawDataEnabled = 0 [cid= [cid=3691033875]] [this=0x1204e8000]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]AudioDeviceManager::SetRawDataModeForCapture: 0 . [cid=3691033875] [this=0x1204e8618]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]AudioDeviceManager::SetRawDataModeForPlayback: 0 . [cid=3691033875] [this=0x1204e8618]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=3691033875]AudioDeviceManager::SetTrainSolutionFlag: 0 . [cid=3691033875] [this=0x1204e8618]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeAudioDataPlaybackEngMgr::CWmeAudioDataPlaybackEngMgr() end [this=0x6000001579c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::InitAudioEnvironment,line=1849 [cid=3691033875] [this=0x140725440] Leave, cost=19ms"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 4 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeAudioDeviceNotifier::CWmeAudioDeviceNotifier end with WmeDeviceInOutType:0 [this=0x600001b5f0c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::RegisterNotification(), pSink=0x600001b5f0e0, list size=1 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 5 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 6 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeAudioDeviceNotifier::Init() end [this=0x600001b5f0c0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::CreateMediaDevicesNotifier, create, m_pAudioDeviceNotifierIn = 0x600001b5f0c0 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CreateMediaDevicesNotifier,line=670 [cid=3691033875] [this=0x140725440] Leave, cost=19ms"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeObserverManager::addMember, obs=0x14220f658 [this=0x60000042df80]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CreateAudioVolumeController,line=904 [cid=3691033875] [this=0x140725440] Enter..., iType=0"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeAudioVolumeController::CWmeAudioVolumeController() end. [this=0x140940a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeAudioVolumeController::Init,line=52 [this=0x140940a00] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 7 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 8 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 9 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10e]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::Release(), Reference count = 6 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10e]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::RegisterNotification(),async push to Observer list, pSink=0x600001b5f0e0 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]:WBXVolumeControlMac::WBXVolumeControlMac(), flow: 0, m_DeviceID:98, sCoreID:BuiltInMicrophoneDevice,m_iSpeakerVolume:0,m_iMicrophoneVolume:12287 [this=0x1414e1c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::CreateVolumeControl(), dwWaveID:98,  flow:0, sFriendlyName:*ac*oo* P*o *ic*op*one, exitRecover:1, volumeCtrl:0x1414e1c00 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::Release(), Reference count = 8 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeAudioVolumeController::createVolumeController(),GetVolumeControl deviceIn type = 0,m_recordDevice sGUID: , sFriendlyName:*ac*oo* P*o *icrophone [this=0x140940a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295][MACOSX ]:WBXVolumeControlMac::RegisterNotification(), m_DeviceID:98, m_iType:0, sCoreID:BuiltInMicrophoneDevice,pSink:0x140940a18 [cid=4294967295] [this=0x1414e1c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295][MACOSX ]:WBXVolumeControlMac::RegisterNotification(), add new DataSink = 0x140940a18, vector size = 1 [cid=4294967295] [this=0x1414e1c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]:WBXVolumeChangeListenerMac::AddVolumeCtrlObserver(),pVolCtrl:0x1414e1c00 [this=0x107b11ac0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]:WBXVolumeChangeListenerMac::AddInputDeviceListeners(),input:98 [this=0x107b11ac0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]:WBXVolumeChangeListenerMac::AddMicMuteVolumeListeners(),input:98 [this=0x107b11ac0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]:WBXDeviceChangeListenerMac::AddMicMuteVolumeListeners() kAudioDevicePropertyMute err = 1852797029 [this=0x107b11ac0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295][MACOSX ]:WBXVolumeControlMac::RegisterNotification(), add to listener [cid=4294967295] [this=0x1414e1c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.080Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295][MACOSX ]:WBXVolumeControlMac::IsMute(), m_DeviceID:98, m_iType:0, sCoreID:BuiltInMicrophoneDevice, mute= 0, system volume=12287 [cid=4294967295] [this=0x1414e1c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295][MACOSX ]:WBXVolumeControlMac::IsMute(), m_DeviceID:98, m_iType:0, sCoreID:BuiltInMicrophoneDevice, mute= 0, system volume=12287 [cid=4294967295] [this=0x1414e1c00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeAudioVolumeController::Init(), Application Volume :12287, System Volume :12287, Application Mute status :0, System Mute status :0 [this=0x140940a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeAudioVolumeController::Init,line=52 [this=0x140940a00] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CreateAudioVolumeController,line=904 [cid=3691033875] [this=0x140725440] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CreateMediaDevicesNotifier,line=670 [cid=3691033875] [this=0x140725440] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 8 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeAudioDeviceNotifier::CWmeAudioDeviceNotifier end with WmeDeviceInOutType:1 [this=0x600001b48be0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::RegisterNotification(), pSink=0x600001b48c00, list size=2 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 9 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 10 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeAudioDeviceNotifier::Init() end [this=0x600001b48be0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10e]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::Release(), Reference count = 10 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeMediaEngine::CreateMediaDevicesNotifier, create, m_pAudioDeviceNotifierOut = 0x600001b48be0 [this=0x140725440]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10e]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::RegisterNotification(),async push to Observer list, pSink=0x600001b48c00 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CreateMediaDevicesNotifier,line=670 [cid=3691033875] [this=0x140725440] Leave"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeObserverManager::addMember, obs=0x14220f658 [this=0x600000438980]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeMediaEngine::CreateAudioVolumeController,line=904 [cid=3691033875] [this=0x140725440] Enter..., iType=1"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeAudioVolumeController::CWmeAudioVolumeController() end. [this=0x143844600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[UTIL] WMEFunc wme::CWmeAudioVolumeController::Init,line=52 [this=0x143844600] Enter..."
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 10 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 11 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::AddRef(), Reference count = 12 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295][MACOSX ]:WBXVolumeControlMac::GetSpeakerVolume,nType:0,volume:0, m_DeviceID:91, sCoreID:BuiltInSpeakerDevice,err:0 [cid=4294967295] [this=0x143074800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]:WBXVolumeControlMac::WBXVolumeControlMac(), flow: 1, m_DeviceID:91, sCoreID:BuiltInSpeakerDevice,m_iSpeakerVolume:0,m_iMicrophoneVolume:0 [this=0x143074800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::CreateVolumeControl(), dwWaveID:91,  flow:1, sFriendlyName:*ac*oo* P*o *pe*ke*s, exitRecover:1, volumeCtrl:0x143074800 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd2a10d]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295]AudioDeviceEnumerator::Release(), Reference count = 12 [cid=4294967295] [this=0x142224a00]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[WME] CWmeAudioVolumeController::createVolumeController(),GetVolumeControl deviceOut type= 1, m_playbackDevice sGUID:, sFriendlyName:*ac*oo* P*o *peakers [this=0x143844600]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295][MACOSX ]:WBXVolumeControlMac::RegisterNotification(), m_DeviceID:91, m_iType:1, sCoreID:BuiltInSpeakerDevice,pSink:0x143844618 [cid=4294967295] [this=0x143074800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine]  [Callid=4294967295][MACOSX ]:WBXVolumeControlMac::RegisterNotification(), add new DataSink = 0x143844618, vector size = 1 [cid=4294967295] [this=0x143074800]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]:WBXVolumeChangeListenerMac::AddVolumeCtrlObserver(),pVolCtrl:0x143074800 [this=0x107b11ac0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Info",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] [MACOSX ]:WBXVolumeChangeListenerMac::AddOutputDeviceListeners(),output:91 [this=0x107b11ac0]"
+        ]
+    },
+    {
+        "timestamp": "2025-01-16T14:18:52.081Z",
+        "level": "Warn",
+        "thread ID": "[0xd1b92b]",
+        "messages": [
+            "[]WME:0 ::[AudioEngine] WBXDeviceChangeListenerMac::AddOutputVolumeListeners() kAudioDevicePropertyVolumeScalar err = 1852797029"
+        ]
+    }
+]

--- a/src/main.js
+++ b/src/main.js
@@ -67,17 +67,17 @@ function highlightText(text, filters) {
   return highlighted;
 }
 
-const renderTable = (logs) => {
-  const logViewer = document.getElementById("log-viewer");
+const renderTable = (logs, id) => {
+  const table = document.getElementById(id || "filtered-logs");
   if (logs.length === 0) {
-    logViewer.innerHTML = `<p class="text-muted">No logs match your search criteria.</p>`;
+    table.innerHTML = `<p class="text-muted">No logs match your search criteria.</p>`;
     return;
   }
 
   const headers = Object.keys(logs[0]);
   const filters = generalFilter && generalFilter.text ? [generalFilter, ...currentFilters] : currentFilters;
   const tableHTML = `
-    <table class="table table-striped table-bordered">
+    <table class="table table-striped table-bordered text-nowrap small">
       <thead class="table-dark">
         <tr>${headers.map(header => `<th>${header}</th>`).join('')}</tr>
       </thead>
@@ -89,7 +89,7 @@ const renderTable = (logs) => {
     </table>
   `;
 
-  logViewer.innerHTML = tableHTML;
+  table.innerHTML = tableHTML;
 };
 
 const loadLogs = () => {
@@ -97,15 +97,16 @@ const loadLogs = () => {
     .then(response => response.json())
     .then(data => {
       if (!Array.isArray(data)) {
-        document.getElementById("log-viewer").innerHTML = `<p class="text-danger">Invalid log format.</p>`;
+        document.getElementById("filtered-logs").innerHTML = `<p class="text-danger">Invalid log format.</p>`;
         return;
       }
       allLogs = data;
-      renderTable(allLogs);
+      renderTable(allLogs, "all-logs");
+      renderTable(allLogs, "filtered-logs");
     })
     .catch(err => {
       console.error("Failed to load logs:", err);
-      document.getElementById("log-viewer").innerHTML = `<p class="text-danger">Failed to load logs.</p>`;
+      document.getElementById("filtered-logs").innerHTML = `<p class="text-danger">Failed to load logs.</p>`;
     });
 };
 
@@ -126,7 +127,8 @@ const handleFileUpload = (event) => {
 
       // Update allLogs and render the table
       allLogs = data;
-      renderTable(allLogs);
+      renderTable(allLogs, "all-logs");
+      renderTable(allLogs, "filtered-logs");
     } catch (error) {
       alert("Error parsing the JSON file. Please upload a valid JSON file.");
     }
@@ -136,7 +138,8 @@ const handleFileUpload = (event) => {
 
 const applyFilters = (filters) => {
   if (filters.length === 0) {
-    renderTable(allLogs);
+    renderTable(allLogs, "all-logs");
+    renderTable(allLogs, "filtered-logs");
     return;
   }
 
@@ -159,7 +162,8 @@ const applyFilters = (filters) => {
       filteredLogs.push(log);
     };
   }
-  renderTable(filteredLogs);
+  renderTable(allLogs, "all-logs");
+  renderTable(filteredLogs, "filtered-logs");
 };
 
 const updateSearchSuggestions = () => {
@@ -390,7 +394,7 @@ const saveFilterGroup = (index = null) => {
   currentFilters = selectedIndices.flatMap((index) => filterGroups[index].filters);
   const filterToApply = generalFilter && generalFilter.text ? [generalFilter, ...currentFilters] : currentFilters;
   applyFilters(filterToApply);
-  
+
   // Automatically close the dropdown menu after saving
   const dropdownMenu = document.querySelector(".dropdown-menu");
   dropdownMenu.classList.remove("show");
@@ -587,15 +591,15 @@ const initializeApp = () => {
   document.getElementById("add-filter-group-btn").addEventListener("click", () => {
     // Set the modal title to "Add Custom Filter Group"
     document.querySelector("#filterGroupModal .modal-title").textContent = "Add Custom Filter Group";
-  
+
     // Clear modal inputs for creating a new filter group
     document.getElementById("filter-group-title").value = '';
     document.getElementById("filter-group-description").value = '';
     document.getElementById("filter-list").innerHTML = '';
-  
+
     // Add one blank filter by default
     addFilterGroup();
-  
+
     // Set up modal footer buttons
     const modalFooter = document.querySelector("#filterGroupModal .modal-footer");
     modalFooter.innerHTML = `
@@ -604,10 +608,10 @@ const initializeApp = () => {
         <button type="button" id="save-filter-group-btn" class="btn btn-success">Save</button>
       </div>
     `;
-  
+
     // Attach event listener for dynamically adding filters in the modal
     document.getElementById("add-filter-btn").addEventListener("click", addFilterGroup);
-  
+
     // Bind saveFilterGroup without index for adding
     document.getElementById("save-filter-group-btn").onclick = () => saveFilterGroup();
     $('#filterGroupModal').modal('show'); // Show the modal

--- a/src/main.js
+++ b/src/main.js
@@ -92,6 +92,13 @@ const renderTable = (logs, id) => {
   table.innerHTML = tableHTML;
 };
 
+// Helper function to add ids to logs
+const getLogsWithIds = (logs) => {
+  return logs.map((log, index) => {
+    return { id: index + 1, ...log };
+  });
+};
+
 const loadLogs = () => {
   fetch('../logs.json')
     .then(response => response.json())
@@ -100,7 +107,7 @@ const loadLogs = () => {
         document.getElementById("filtered-logs").innerHTML = `<p class="text-danger">Invalid log format.</p>`;
         return;
       }
-      allLogs = data;
+      allLogs = getLogsWithIds(data);
       renderTable(allLogs, "all-logs");
       renderTable(allLogs, "filtered-logs");
     })
@@ -126,7 +133,7 @@ const handleFileUpload = (event) => {
       }
 
       // Update allLogs and render the table
-      allLogs = data;
+      allLogs = getLogsWithIds(data);
       renderTable(allLogs, "all-logs");
       renderTable(allLogs, "filtered-logs");
     } catch (error) {

--- a/src/main.js
+++ b/src/main.js
@@ -577,9 +577,10 @@ const initializeApp = () => {
   document.getElementById("log-file-input").addEventListener("change", handleFileUpload);
 
   // Attach event listeners for text filters
-  document.getElementById("log-search").addEventListener("input", updateTextFilter);
+  // document.getElementById("log-search").addEventListener("input", updateTextFilter); disabled because too slow
   document.getElementById("log-search").addEventListener("keydown", (e) => {
     if (e.key == "Enter") {
+      updateTextFilter();
       updateSearchSugggestionTrie();
     }
   })

--- a/src/main.js
+++ b/src/main.js
@@ -83,7 +83,9 @@ const renderTable = (logs, id) => {
       </thead>
       <tbody>
         ${logs.map(log => `
-          <tr>${headers.map(header => `<td>${highlightText(String(log[header]), filters)}</td>`).join('')}</tr>
+          <tr id="log-${log.id}">
+            ${headers.map(header => `<td>${highlightText(String(log[header]), filters)}</td>`).join('')}
+          </tr>
         `).join('')}
       </tbody>
     </table>
@@ -638,6 +640,28 @@ const initializeApp = () => {
       e.stopPropagation(); // Prevent the event from propagating to other handlers
     }
   });
+
+  // Attach event listener for subset table row clicks
+  const filteredTable = document.getElementById("filtered-logs");
+  if (filteredTable) {
+    filteredTable.addEventListener("click", (e) => {
+      // Use closest() to ensure we get the row (<tr>) even if a child element was clicked.
+      const clickedRow = e.target.closest("tr");
+      if (clickedRow && clickedRow.id) {
+        const rowId = clickedRow.id;
+        // Locate the corresponding row in the full table using its unique id.
+        const fullRow = document.querySelector(`#all-logs tr#${rowId}`);
+        if (fullRow) {
+          fullRow.scrollIntoView({ behavior: "smooth", block: "center" });
+          // Optionally highlight the full table row temporarily.
+          fullRow.classList.add("highlight");
+          setTimeout(() => {
+            fullRow.classList.remove("highlight");
+          }, 2000);
+        }
+      }
+    });
+  }
 
   // Initialize dropdown behavior for toggling
   setupDropdown();

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -145,3 +145,12 @@ button .svg-icon {
   display: block;
 }
 
+/* Make smooth transition for unhighlighting the row */
+#all-logs tr {
+  transition: background-color 0.5s ease-out;
+}
+
+/* Highlight the matching row in all-logs table */
+.highlight {
+  background-color: #ffffc5 !important;
+}


### PR DESCRIPTION
Implemented the feature where I have two tables, one for all rows and one for filtered rows, and when I click on a filtered row it automatically scrolls to that row inside the full table. I haven't done extensive testing on this but for now this works. 

This might be a bit more complicated to implement once we implement paging (necessary for anything larger than 1k rows), but I can already see how to do that so we should be good 👍

Note1: I also preprocessed the entire log file we got to be able to load it into our log viewer, but it was way too big, so I truncated it to 1k rows.

Note2: I disabled responsive filtering (filtering upon any keystroke) for the basic search bar, as it lagged a lot, once again likely due to no paging, but this might be too inefficient anyway for large enough log files, so we might opt to disable it entirely. Now you need to press enter to filter.